### PR TITLE
Switching constitutive law from 2 mu dev d to 2 mu d

### DIFF
--- a/src/Cell.py
+++ b/src/Cell.py
@@ -193,15 +193,24 @@ class Cell(object):
         dyv = dot(self.DshapeY, self.uy)
         
         return array([dxu, dyv, dyu+dxv])
+        
+        #dd = (dxu + dyv) / 3.
+        #return array([dxu-dd, dyv-dd, dyu+dxv])
     
     def GetEnhancedStrainRate(self, xl):
         
         s = xl[0]
         t = xl[1]
         
-        d = [ (self.divVc*t/self.size[1] - 2.*self.divVb*s/self.size[0])/1.5, 
-              (self.divVb*s/self.size[0] - 2.*self.divVc*t/self.size[1])/1.5, 
+        # this is the full rate of deformation tensor
+        d = [ -2.*self.divVb*s/self.size[0], 
+              -2.*self.divVc*t/self.size[1], 
               0.0 ]
+
+        ## this is the deviatoric portion
+        #d = [ (self.divVc*t/self.size[1] - 2.*self.divVb*s/self.size[0])/1.5, 
+        #      (self.divVb*s/self.size[0] - 2.*self.divVc*t/self.size[1])/1.5, 
+        #      0.0 ]
 
         return array(d)
     

--- a/src/Main.py
+++ b/src/Main.py
@@ -20,7 +20,7 @@ def Main():
     # set side-length of the analysis domain
     edgeDomain      = 1.
     # set the number of cells per edge
-    numCellsPerEdge = 4
+    numCellsPerEdge = 8
     
     # viscosity of the fluid
     viscosity = density * velocity * edgeDomain / Re


### PR DESCRIPTION
Switching constitutive law from 2 mu dev d to 2 mu d.  This is equivalent to an orthogonality condition between enhanced modes and traditional modes.  It results in NO additional viscous nodal forces from the enhanced velocity field.